### PR TITLE
[v0.10.0] Add `porter job wait` command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,3 +16,4 @@ paused: false
 ' > values-job.yaml
 
 porter update config --app "$INPUT_JOB" --namespace "$INPUT_NAMESPACE" --values ./values-job.yaml
+porter job wait --name "$INPUT_JOB" --namespace "$INPUT_NAMESPACE"


### PR DESCRIPTION
For release `v0.10.0`, the CLI now supports `porter job wait`, which waits for a job to finish successfully before exiting with status code 0. 